### PR TITLE
sed will now replace ZSH_THEME in ~/.zshrc

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -22,7 +22,6 @@ sh -c '$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.
 cp $DIR/bullet-train.zsh-theme $HOME/.oh-my-zsh/custom/bullet-train.zsh-theme
 
 # Modify .zshrc to use bullet-train theme
-sed -i "s/^ZSH_THEME=.*^/ZSH_THEME=\"bullet-train\"/" $HOME/.zshrc
+sed -i 's~\(ZSH_THEME="\)[^"]*\(".*\)~\1bullet-train\2~' $HOME/.zshrc
 
 echo "Completed"
-


### PR DESCRIPTION
The ZSH_THEME will now be properly replaced in the user's .zshrc

![image](https://user-images.githubusercontent.com/22060245/90992645-a2f95a00-e5a0-11ea-8546-5b17a8d846e1.png)

Fixes #3
